### PR TITLE
feat: add degree notations to Profile page education section

### DIFF
--- a/apps/frontend/src/app/[locale]/profile/page.tsx
+++ b/apps/frontend/src/app/[locale]/profile/page.tsx
@@ -101,6 +101,7 @@ export default function ProfilePage({ params }: { params: { locale: string } }) 
                   </a>
                 </h3>
                 <p className="text-sm text-muted-foreground">{t('profile.graduateSchoolPeriod')}</p>
+                <p className="text-xs text-muted-foreground">{t('profile.graduateSchoolDegree')}</p>
               </div>
               <div className="border-l-4 border-green-500 pl-4">
                 <h3 className="font-semibold text-foreground">
@@ -116,6 +117,9 @@ export default function ProfilePage({ params }: { params: { locale: string } }) 
                 </h3>
                 <p className="text-sm text-muted-foreground">
                   {t('profile.undergraduateSchoolPeriod')}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {t('profile.undergraduateSchoolDegree')}
                 </p>
               </div>
               <div className="border-l-4 border-purple-500 pl-4">

--- a/apps/frontend/src/lib/i18n.ts
+++ b/apps/frontend/src/lib/i18n.ts
@@ -27,7 +27,6 @@ export const translations = {
     'profile.bio3':
       'Additionally, I have actively engaged in various activities, including leading projects as a development team leader in internships, and participating in SecHack365, 42 Tokyo, Interop STM, and speaking at Wakamonog outside of work.',
     'profile.value': 'Value',
-    'profile.valueTitle': 'Three Core Values I Cherish in Life',
     'profile.valuePara1':
       'The three pillars I value in life are "enjoyable things," "things that lead to growth," and "things that contribute to society." These complement each other, and I believe that without any one of them, I cannot live with satisfaction.',
     'profile.valuePara2':
@@ -42,9 +41,11 @@ export const translations = {
     'profile.graduateSchool':
       'Keio University Graduate School of Media and Governance (Cyber Informatics)',
     'profile.graduateSchoolPeriod': '2025/04 - 2027/03 (Expected)',
+    'profile.graduateSchoolDegree': 'Master of Media and Governance',
     'profile.undergraduateSchool':
       'Keio University Faculty of Environment and Information Studies (SFC)',
     'profile.undergraduateSchoolPeriod': '2022/04 - 2025/03',
+    'profile.undergraduateSchoolDegree': 'Bachelor of Arts in Environment and Information Studies',
     'profile.lawSchool': 'Keio University Faculty of Law',
     'profile.lawSchoolPeriod': '2020/04 - 2022/03',
     'profile.highSchool': 'Sakaehigashi High School',
@@ -186,8 +187,10 @@ export const translations = {
     'profile.education': '学歴',
     'profile.graduateSchool': '慶應義塾大学 政策・メディア研究科（サイバーインフォマティクス）',
     'profile.graduateSchoolPeriod': '2025/04 - 2027/03 (予定)',
+    'profile.graduateSchoolDegree': '修士（政策・メディア）',
     'profile.undergraduateSchool': '慶應義塾大学 環境情報学部（SFC）',
     'profile.undergraduateSchoolPeriod': '2022/04 - 2025/03',
+    'profile.undergraduateSchoolDegree': '学士（環境情報学）',
     'profile.lawSchool': '慶應義塾大学 法学部法律学科',
     'profile.lawSchoolPeriod': '2020/04 - 2022/03',
     'profile.highSchool': '栄東高等学校',

--- a/docs/profile.md
+++ b/docs/profile.md
@@ -34,7 +34,9 @@
 ## 学歴
 
 - 慶應義塾大学 政策・メディア研究科 [サイバーインフォマティクス](https://www.sfc.keio.ac.jp/academics/gsmg/program/ci.html) 2025/04~2027/03
+  - 修士（政策・メディア）Master of Media and Governance
 - 慶應義塾大学 環境情報学部（通称[SFC](https://www.sfc.keio.ac.jp/)） 2022/04~2025/03
+  - 学士（環境情報学）Bachelor of Arts in Environment and Information Studies
 - [慶應義塾大学](https://www.keio.ac.jp/) 法学部法律学科 2020/04~2022/03
 - [栄東高等学校](https://www.sakaehigashi.ed.jp/) 2016/04~2020/03
 - [Rangitoto College](https://www.rangitoto.school.nz/) 2017/04~2018/03


### PR DESCRIPTION
## Why
Update the Profile page to include specific degree information that was recently added to the docs/profile.md file. This provides visitors with more detailed information about educational qualifications.

## What & How
- **Added degree translations**: Added Japanese and English degree names to i18n.ts for both graduate school (修士（政策・メディア）/ Master of Media and Governance) and undergraduate (学士（環境情報学）/ Bachelor of Arts in Environment and Information Studies)
- **Updated Profile component**: Modified the education section in `/apps/frontend/src/app/[locale]/profile/page.tsx` to display degree information below school name and period
- **Synced documentation**: Updated docs/profile.md with the same degree information to maintain consistency between documentation and site content
- **Cleaned up unused keys**: Removed unused `profile.valueTitle` translation key

The degree information now appears as small text below each education entry in both Japanese and English locales.

## Note
- All changes maintain the existing bilingual approach with proper Japanese and English translations
- The styling uses `text-xs` to keep degree information subtle but visible
- Changes are fully tested with TypeScript, ESLint, and Prettier validation
- Documentation and site content remain synchronized as required by project guidelines

🤖 Generated with [Claude Code](https://claude.ai/code)